### PR TITLE
Fix validCIF accepting NIE prefixes (X/Y/Z)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export const validCIF = (str: string) => {
   let i
   let digit
 
-  if (!letter.match(/[A-Z]/)) {
+  if (!letter.match(/[ABCDEFGHJKLMNPQRSUVW]/)) {
     return false
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -60,4 +60,12 @@ describe('Id validations', () => {
     expect(validNIE('X8095495F')).toBeFalsy()
     expect(validateSpanishId('X8095495F')).toBeFalsy()
   })
+  test('validCIF should reject NIE id X7564244G (issue #33)', () => {
+    expect(spainIdType('X7564244G')).toBe('nie')
+    expect(validNIE('X7564244G')).toBeTruthy()
+    expect(validCIF('X7564244G')).toBeFalsy()
+    // X7564244G is a valid NIE, so validateSpanishId is true,
+    // but it must never be treated as a CIF
+    expect(validateSpanishId('X7564244G')).toBeTruthy()
+  })
 })


### PR DESCRIPTION
validCIF only checked that the first character was any uppercase letter (/[A-Z]/), so NIE documents starting with X, Y or Z could be incorrectly validated as a CIF (e.g. validCIF('X7564244G') === true).

Restrict the control-letter check to the set of valid CIF organization letters (ABCDEFGHJKLMNPQRSUVW), matching CIF_REGEX. Add a regression test for the case reported in issue #33.

Fixes #33