### PR TITLE
Fix validCIF accepting NIE prefixes (#33) + automate npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Automates versioning + npm publishing for spain-id.
+#
+# Flow:
+#   1. A push to `master` (or a manual run) builds and tests the package.
+#   2. The version is bumped (patch by default; choose the level for manual runs).
+#   3. The bump commit + tag are pushed back to `master` (commit tagged with
+#      [skip ci] so it does not re-trigger this workflow).
+#   4. A GitHub Release is created for the new tag.
+#   5. The package is published to npm with provenance.
+#
+# Required setup (one-time):
+#   - Repo secret NPM_TOKEN: an npm automation token with publish rights on
+#     the `spain-id` package (Settings -> Secrets and variables -> Actions).
+#   - Allow github-actions[bot] to push to the protected `master` branch:
+#     either add it to the branch-protection bypass list, or relax the rule.
+#     Without this, the "Push commit and tag" step will fail.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Semver bump for this release"
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+# Never run two releases at once.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push the bump commit/tag and create the GitHub Release
+  id-token: write   # npm publish --provenance
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip the run triggered by our own bump commit.
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump
+        run: |
+          NEW_VERSION="$(npm version "${{ github.event.inputs.release-type || 'patch' }}" -m 'chore(release): %s [skip ci]')"
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Push commit and tag
+        run: git push --follow-tags origin "HEAD:${{ github.ref_name }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.version }}" \
+            --title "${{ steps.bump.outputs.version }}" \
+            --generate-notes
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,14 @@ name: Release
 #   3. The bump commit + tag are pushed back to `master` (commit tagged with
 #      [skip ci] so it does not re-trigger this workflow).
 #   4. A GitHub Release is created for the new tag.
-#   5. The package is published to npm with provenance.
+#   5. The package is published to npm via OIDC trusted publishing (with
+#      automatic provenance) -- no npm token required.
 #
 # Required setup (one-time):
-#   - Repo secret NPM_TOKEN: an npm automation token with publish rights on
-#     the `spain-id` package (Settings -> Secrets and variables -> Actions).
+#   - npm trusted publisher: already configured for this repo + release.yml,
+#     scoped to the `deploy` environment. No NPM_TOKEN secret is needed.
+#   - GitHub environment `deploy` must exist (Settings -> Environments) so the
+#     publish job can run in it and the OIDC claim matches the npm config.
 #   - Allow github-actions[bot] to push to the protected `master` branch:
 #     either add it to the branch-protection bypass list, or relax the rule.
 #     Without this, the "Push commit and tag" step will fail.
@@ -38,11 +41,13 @@ concurrency:
 
 permissions:
   contents: write   # push the bump commit/tag and create the GitHub Release
-  id-token: write   # npm publish --provenance
+  id-token: write   # OIDC token for npm trusted publishing + provenance
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Must match the environment configured on the npm trusted publisher.
+    environment: deploy
     # Skip the run triggered by our own bump commit.
     if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
@@ -56,6 +61,10 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -88,7 +97,6 @@ jobs:
             --title "${{ steps.bump.outputs.version }}" \
             --generate-notes
 
+      # Authenticated via OIDC trusted publishing; no NODE_AUTH_TOKEN needed.
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,26 @@ name: Release
 
 # Automates versioning + npm publishing for spain-id.
 #
-# Flow:
+# Tag-based flow -- nothing is ever committed to `master`, so the branch's
+# protection rules are never touched:
 #   1. A push to `master` (or a manual run) builds and tests the package.
-#   2. The version is bumped (patch by default; choose the level for manual runs).
-#   3. The bump commit + tag are pushed back to `master` (commit tagged with
-#      [skip ci] so it does not re-trigger this workflow).
-#   4. A GitHub Release is created for the new tag.
-#   5. The package is published to npm via OIDC trusted publishing (with
-#      automatic provenance) -- no npm token required.
+#   2. The next version is computed from the latest version published on npm
+#      (patch by default; choose the level for manual runs) and written into
+#      package.json in the runner only (never committed).
+#   3. The package is published to npm via OIDC trusted publishing (automatic
+#      provenance, no token stored).
+#   4. A matching tag + GitHub Release are created at the released commit.
+#
+# Note: the version committed in package.json on `master` is just a baseline;
+# the real version of each release lives in the git tag / GitHub Release and
+# on npm. This is intentional -- it lets releases run without pushing to the
+# protected `master` branch.
 #
 # Required setup (one-time):
-#   - npm trusted publisher: already configured for this repo + release.yml,
-#     scoped to the `deploy` environment. No NPM_TOKEN secret is needed.
+#   - npm trusted publisher: configured for this repo + release.yml, scoped to
+#     the `deploy` environment. No NPM_TOKEN secret is needed.
 #   - GitHub environment `deploy` must exist (Settings -> Environments) so the
-#     publish job can run in it and the OIDC claim matches the npm config.
-#   - Allow github-actions[bot] to push to the protected `master` branch:
-#     either add it to the branch-protection bypass list, or relax the rule.
-#     Without this, the "Push commit and tag" step will fail.
+#     publish job runs in it and the OIDC claim matches the npm config.
 
 on:
   push:
@@ -40,7 +43,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write   # push the bump commit/tag and create the GitHub Release
+  contents: write   # create the tag + GitHub Release
   id-token: write   # OIDC token for npm trusted publishing + provenance
 
 jobs:
@@ -48,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     # Must match the environment configured on the npm trusted publisher.
     environment: deploy
-    # Skip the run triggered by our own bump commit.
+    # Let maintainers skip a release with [skip ci] in the commit message.
     if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
       - name: Checkout
@@ -75,28 +78,31 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Configure git author
+      - name: Compute next version
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump version
-        id: bump
-        run: |
-          NEW_VERSION="$(npm version "${{ github.event.inputs.release-type || 'patch' }}" -m 'chore(release): %s [skip ci]')"
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Push commit and tag
-        run: git push --follow-tags origin "HEAD:${{ github.ref_name }}"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ steps.bump.outputs.version }}" \
-            --title "${{ steps.bump.outputs.version }}" \
-            --generate-notes
+          BUMP="${{ github.event.inputs.release-type || 'patch' }}"
+          # Seed from the latest version published on npm; fall back to
+          # package.json the very first time the package is unpublished.
+          BASE="$(npm view "$(node -p "require('./package.json').name")" version 2>/dev/null || true)"
+          if [ -z "$BASE" ]; then
+            BASE="$(node -p "require('./package.json').version")"
+          fi
+          # Write the baseline, then bump -- no commit, no git tag.
+          npm version "$BASE" --no-git-tag-version --allow-same-version >/dev/null
+          NEW="$(npm version "$BUMP" --no-git-tag-version)"
+          echo "Releasing $NEW (from $BASE, bump $BUMP)"
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
 
       # Authenticated via OIDC trusted publishing; no NODE_AUTH_TOKEN needed.
       - name: Publish to npm
         run: npm publish
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "patch": "npm version patch",
     "tsc": "tsc -p tsconfig.json && mv ./lib/esm/index.js ./lib/esm/index.mjs && tsc -p tsconfig-cjs.json && mv ./lib/cjs/index.js ./lib/cjs/index.cjs",
     "copy-dts": "tee ./lib/esm/index.d.ts ./lib/cjs/index.d.ts < ./src/index.d.ts",
+    "build": "npm run tsc && npm run copy-dts",
     "tdd": "jest --watchAll",
-    "prepare": "npm run tsc && npm run copy-dts && npm run test && npm run patch"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

This PR contains two related changes.

### 1. Fix `validCIF` accepting NIE documents (closes #33)

`validCIF()` only checked that the first character was *any* uppercase letter (`/[A-Z]/`), so NIE documents starting with `X`/`Y`/`Z` could be incorrectly validated as a CIF — e.g. `validCIF('X7564244G')` returned `true`.

The check is now restricted to the valid CIF organization letters (`ABCDEFGHJKLMNPQRSUVW`), matching `CIF_REGEX`. A regression test for the reported case is included.

Note: `validateSpanishId('X7564244G')` correctly returns `true`, because `X7564244G` is a genuinely valid **NIE** (the reporter's `spainIdType` result of `"nie"` was right). Only the `validCIF` route was buggy.

Verified against the compiled output:
- `validCIF('X7564244G')` → `false` (was `true`)
- `spainIdType('X7564244G')` → `'nie'`
- Valid CIFs (`A28017895`, `P4622000J`, `B72327000`) still → `true`

### 2. Automate versioning + npm publishing (tag-based)

New `.github/workflows/release.yml`. On every push to `master` (or a manual dispatch) it:
1. Builds and tests the package
2. Computes the next version from the latest version published on npm (patch by default; `minor`/`major` selectable on manual runs) — written into `package.json` in the runner only
3. Publishes to npm via **OIDC trusted publishing** (automatic provenance, no token stored)
4. Creates a matching **tag + GitHub Release** at the released commit

**Nothing is ever committed to `master`**, so the branch's protection rules are never touched (the default `GITHUB_TOKEN` cannot bypass a "require pull request" rule, and tags are not subject to branch protection). The version committed in `package.json` is just a baseline; the real version of each release lives in the git tag / GitHub Release and on npm.

Also simplifies the `prepare` script to only build the package; it previously ran `npm version patch` on every install, which is unsafe in CI and for consumers installing from git.

## One-time setup required before the first release

- **GitHub environment `deploy`** must exist (Settings → Environments) to match the npm trusted-publisher config. Leave it without protection rules for fully-automatic releases, or add required reviewers if you want a manual checkpoint before each publish.
- No `NPM_TOKEN` secret and no branch-protection changes are needed — authentication uses OIDC trusted publishing, and releases never push to `master`.

https://claude.ai/code/session_01Nn8AihyY7db8PxomRcasRo