### PR TITLE
chore: tune Dependabot — ignore eslint majors, auto-merge majors on green CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       dev-dependencies:
         patterns:
           - "*"
+    ignore:
+      # neostandard's eslint peer dependency is currently ^9. Hold eslint at
+      # 9 until neostandard ships eslint 10 support, then bump them together
+      # manually (a major eslint bump alone breaks `npm ci`).
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,11 +1,13 @@
 name: Dependabot auto-merge
 
-# Auto-approves and enables auto-merge for Dependabot PRs limited to patch
-# and minor updates. GitHub then merges them automatically once the required
-# CI check (see ci.yml) passes. Major updates are left for manual review.
+# Approves and enables auto-merge for every Dependabot PR, including majors.
+# GitHub only completes the merge once the required CI check (ci.yml: lint +
+# typecheck/build + test) passes, so CI is the sole gate. This is safe here
+# because the package has no runtime dependencies -- every update is dev-only
+# tooling that never ships to consumers.
 #
-# Requires "Allow auto-merge" to be enabled in repo settings, and the CI
-# check to be marked as required in branch protection.
+# Requires "Allow auto-merge" in repo settings and the `build` check marked as
+# required in branch protection.
 
 on: pull_request
 
@@ -18,14 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Fetch Dependabot metadata
-        id: meta
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Approve and enable auto-merge (patch/minor only)
-        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+      - name: Approve and enable auto-merge
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Two related Dependabot-automation tweaks, prompted by #38 failing CI.

## 1. Ignore incompatible eslint major bumps

The grouped dev-dependencies PR (#38) failed at `npm ci`:

```
npm error Conflicting peer dependency: eslint@9.39.4
npm error   peer eslint@"^9.0.0" from neostandard@0.13.0
```

eslint 10 isn't supported by `neostandard` yet. Ignore eslint **major** updates until neostandard catches up (then bump both together manually). Patch/minor eslint updates still flow. This avoids a perpetually-red PR being recreated every week for a *known* hard incompatibility.

## 2. Auto-merge majors, gated on CI

Drop the major-version exclusion from `dependabot-auto-merge.yml`, so **every** Dependabot PR is approved and set to auto-merge — and GitHub only completes the merge once the required `build` check passes.

Rationale: the package has **no runtime dependencies**, so every update is dev-only tooling that never ships. The `build` job runs **lint + typecheck (tsc) + test + build** in one check, so "green" means all four passed. Install-incompatible majors (like the eslint case above) fail `npm ci` and are blocked automatically. This removes the need to manually merge routine major bumps (e.g. GitHub Actions version jumps like #37).

## Follow-up after merge
Once this lands I'll comment `@dependabot recreate` on #38 so it regenerates without the eslint major (leaving just the typescript/neostandard bumps, which will then pass CI and auto-merge).

## Reminder to activate
This only takes effect once **"Allow auto-merge"** is enabled (Settings → General) and **`build`** is a **required** status check on `master`.

https://claude.ai/code/session_01Nn8AihyY7db8PxomRcasRo